### PR TITLE
2.0: a few hours of work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.airbnb.billow</groupId>
     <artifactId>billow</artifactId>
-    <version>1.5</version>
+    <version>2.0</version>
 
     <licenses>
         <license>
@@ -104,6 +104,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-guava</artifactId>
             <version>${jackson.version}</version>
         </dependency>
 

--- a/src/main/java/com/airbnb/billow/EC2Instance.java
+++ b/src/main/java/com/airbnb/billow/EC2Instance.java
@@ -14,8 +14,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@JsonFilter("InstanceFilter")
+@JsonFilter(EC2Instance.INSTANCE_FILTER)
 public class EC2Instance {
+    public static final String INSTANCE_FILTER = "InstanceFilter";
+
     @Getter
     private final String id;
     @Getter

--- a/src/main/java/com/airbnb/billow/IAMUserWithKeys.java
+++ b/src/main/java/com/airbnb/billow/IAMUserWithKeys.java
@@ -1,0 +1,12 @@
+package com.airbnb.billow;
+
+import com.amazonaws.services.identitymanagement.model.AccessKeyMetadata;
+import com.amazonaws.services.identitymanagement.model.User;
+import com.google.common.collect.ImmutableList;
+import lombok.Data;
+
+@Data
+public class IAMUserWithKeys {
+    private final User user;
+    private final ImmutableList<AccessKeyMetadata> keys;
+}

--- a/src/main/java/com/airbnb/billow/Main.java
+++ b/src/main/java/com/airbnb/billow/Main.java
@@ -22,6 +22,7 @@ import org.quartz.impl.StdSchedulerFactory;
 
 import javax.servlet.ServletContext;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.io.Resources.getResource;
 import static org.quartz.JobBuilder.newJob;
@@ -46,7 +47,7 @@ public class Main {
         log.info("Creating database");
 
         final Config awsConfig = config.getConfig("aws");
-        final Long refreshRate = awsConfig.getMilliseconds("refreshRate");
+        final Long refreshRate = awsConfig.getDuration("refreshRate", TimeUnit.MILLISECONDS);
 
         final AWSDatabaseHolder dbHolder = new AWSDatabaseHolder(awsConfig);
 
@@ -82,7 +83,7 @@ public class Main {
         configureConnectors(adminServer);
 
         log.info("Creating HTTP handlers");
-        final Handler mainHandler = new Handler(metricRegistry, dbHolder);
+        final Handler mainHandler = new Handler(metricRegistry, dbHolder, refreshRate);
         final InstrumentedHandler instrumentedHandler =
                 new InstrumentedHandler(metricRegistry);
         instrumentedHandler.setHandler(mainHandler);


### PR DESCRIPTION
**General:**
- Few small internal simplifications
- Cache-Control header based on the maximum age acceptable (already in
- config for health checks).

**Per endpoint:**
- `/rds/all` (new): RDS instances endpoint
- `/iam/users` (new): more verbose IAM endpoint
- `/ec2/all` (new): simpler, faster EC2 instances endpoint with all machines per AZ
- `/ec2/sg` (recent and yet to be documented): restructured for per-AZ
