### PR TITLE
set the marker in the request to the marker from the result

### DIFF
--- a/src/main/java/com/airbnb/billow/AWSDatabase.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabase.java
@@ -92,7 +92,7 @@ public class AWSDatabase {
                 final List<DBInstance> instances = result.getDBInstances();
                 log.debug("Found {} RDS instances", instances.size());
                 rdsBuilder.putAll(regionName, instances);
-                rdsRequest.setMarker(rdsRequest.getMarker());
+                rdsRequest.setMarker(result.getMarker());
             } while (result.getMarker() != null);
         }
         this.rdsInstances = rdsBuilder.build();


### PR DESCRIPTION
There was a small bug in the code that executed a no-op when it was supposed to update a pagination key in the request.

The "marker" is a pagination key, specifying where the last request left off. The new code updates the marker in the request to be the marker that was passed back in the result.

@nelgau @jtai @joshbuddy 
