### PR TITLE
Handle and log error when a DB instance cannot be found

### DIFF
--- a/src/main/java/com/airbnb/billow/AWSDatabase.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabase.java
@@ -12,6 +12,7 @@ import com.amazonaws.services.identitymanagement.model.ListUsersResult;
 import com.amazonaws.services.identitymanagement.model.User;
 import com.amazonaws.services.rds.AmazonRDSClient;
 import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DBInstanceNotFoundException;
 import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
 import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
 import com.amazonaws.services.rds.model.ListTagsForResourceRequest;
@@ -103,10 +104,19 @@ public class AWSDatabase {
                     ListTagsForResourceRequest tagsRequest = new ListTagsForResourceRequest()
                             .withResourceName(arnGenerator.rdsARN(regionName, instance));
 
-                    ListTagsForResourceResult tagsResult = client.listTagsForResource(tagsRequest);
+                    try {
+                        ListTagsForResourceResult tagsResult = client.listTagsForResource(tagsRequest);
 
-                    rdsBuilder.putAll(regionName, new RDSInstance(instance, tagsResult.getTagList()));
-
+                        rdsBuilder.putAll(regionName, new RDSInstance(instance, tagsResult.getTagList()));
+                    } catch(DBInstanceNotFoundException e) {
+                        // It is possible for an instance to disappear between when we got the list of instances and
+                        // when we go to find the instance's tags.
+                        log.warn("Unable to find RDS instance '" +
+                                instance.getDBInstanceIdentifier() +
+                                "', last known status was '" +
+                                instance.getDBInstanceStatus() +
+                                "'.  Exception: " + e.toString());
+                    }
                 }
                 rdsRequest.setMarker(result.getMarker());
             } while (result.getMarker() != null);


### PR DESCRIPTION
Not a huge issue, but this patch prevents some of our rapidly created or destroyed instances from gumming up the works.

/cc @jtai @ktrice 
