### PR TITLE
Add DynamoDB API

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,17 +73,17 @@ Attributes(``readCapacityUnits`` and ``writeCapacityUnits`` are pulled out of
 
 ```
 {
-  "tableName": "user_table",
+  "tableName": "table_foo",
   "attributeDefinitions": "[{AttributeName: foo,AttributeType: S}]",
   "tableStatus": "ACTIVE",
   "keySchema": "[{AttributeName: foo,KeyType: HASH}]",
-  "creationDateTime": 14887890,
+  "creationDateTime":  1457475410,
   "numberOfDecreasesToday": 0,
   "readCapacityUnits": 1,
   "writeCapacityUnits": 1,
   "tableSizeBytes": 0,
   "itemCount": 0,
-  "tableArn": "arn:aws:dynamodb:us-east-1:xxxxx:table/user_table,
+  "tableArn": "arn:aws:dynamodb:us-east-1:user_id:table/table_foo,
   "provisionedThroughput": "{NumberOfDecreasesToday: 0,ReadCapacityUnits: 1,
     WriteCapacityUnits: 1}"
 }
@@ -96,15 +96,15 @@ Sample response:
 ```
 [
   {
-    tableName: "user_join_test",
+    tableName: "table_foo",
     readCapacityUnits: 1
   },
   {
-    tableName: "kincaidscore",
+    tableName: "table_bar",
     readCapacityUnits: 2
   },
   {
-    tableName: "two_factor",
+    tableName: "table_baz",
     readCapacityUnits: 3
   }
 ]

--- a/README.md
+++ b/README.md
@@ -69,18 +69,18 @@ Optional parameters:
   Response
   ```json
   {
-      tableName: "user_join_test",
-      attributeDefinitions: "[{AttributeName: foo,AttributeType: S}]",
-      tableStatus: "ACTIVE",
-      keySchema: "[{AttributeName: foo,KeyType: HASH}]",
-      creationDateTime: 1442960756398,
-      numberOfDecreasesToday: 0,
-      readCapacityUnits: 1,
-      writeCapacityUnits: 1,
-      tableSizeBytes: 0,
-      itemCount: 0,
-      tableArn: "arn:aws:dynamodb:us-east-1:172631448019:table/user_join_test",
-      provisionedThroughput: "{NumberOfDecreasesToday: 0,ReadCapacityUnits: 1,WriteCapacityUnits: 1}"
+      "tableName": "user_join_test",
+      "attributeDefinitions": "[{AttributeName: foo,AttributeType: S}]",
+      "tableStatus": "ACTIVE",
+      "keySchema": "[{AttributeName: foo,KeyType: HASH}]",
+      "creationDateTime": 1442960756398,
+      "numberOfDecreasesToday": 0,
+      "readCapacityUnits": 1,
+      "writeCapacityUnits": 1,
+      "tableSizeBytes": 0,
+      "itemCount": 0,
+      "tableArn": "arn:aws:dynamodb:us-east-1:172631448019:table/user_join_test",
+      "provisionedThroughput": "{NumberOfDecreasesToday: 0,ReadCapacityUnits: 1,WriteCapacityUnits: 1}"
   }
   ```
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,52 @@ Optional parameters:
   - `az,type`
   - `id,publicIP,launchTime`
 
+### /dynamo ###
+
+- `/dynamo/all`
+- `q` / `query`
+- `s` / `sort`
+    - `/dynamo?s=itemCount`
+- `l` / `limit`
+    - `/dynamo?l=10`
+- `f` / `field`
+    * `/dynamo?f=tableName,tableStatus`
+    * tableName
+    * attributeDefinitions
+    * tableStatus
+    * keySchema
+    * creationDateTime
+    * numberOfDecreasesToday
+    * readCapacityUnits
+    * writeCapacityUnits
+    * tableSizeBytes
+    * itemCount
+    * tableArn
+    * provisionedThroughput
+
+  Response
+  ```json
+  {
+      tableName: "user_join_test",
+      attributeDefinitions: "[{AttributeName: foo,AttributeType: S}]",
+      tableStatus: "ACTIVE",
+      keySchema: "[{AttributeName: foo,KeyType: HASH}]",
+      creationDateTime: 1442960756398,
+      numberOfDecreasesToday: 0,
+      readCapacityUnits: 1,
+      writeCapacityUnits: 1,
+      tableSizeBytes: 0,
+      itemCount: 0,
+      tableArn: "arn:aws:dynamodb:us-east-1:172631448019:table/user_join_test",
+      provisionedThroughput: "{NumberOfDecreasesToday: 0,ReadCapacityUnits: 1,WriteCapacityUnits: 1}"
+  }
+  ```
+
+  ```
+  http://10.1.148.94:8080/dynamo?s=readCapacityUnits&&f=readCapacityUnits,tableName
+  ```
+
+
 ### /iam ###
 
 List IAM user credentials.
@@ -73,6 +119,8 @@ Here is the required User Policy:
         }
       ]
     }
+
+
 
 
 ### Local configuration ###

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # billow: inspect the cloud #
 
 **As-is:** This project is not actively maintained or supported.
-While updates may still be made and we welcome feedback, keep in mind we may not respond to pull requests or issues quickly.
+While updates may still be made and we welcome feedback, keep in mind we may not respond to pull
+requests or issues quickly.
 
-**Let us know!** If you fork this, or if you use it, or if it helps in anyway, we'd love to hear from you! opensource@airbnb.com
+**Let us know!** If you fork this, or if you use it, or if it helps in anyway, we'd love to hear
+from you! opensource@airbnb.com
 
 ## Goal ##
 
@@ -31,9 +33,10 @@ Optional parameters:
 
 - `q`/`query`: OGNL expression used to filter (defaults to all instances). Examples:
 
-  - `state=="running" && key=="pierre" && launchTime > 1365000000000`
+  - `state=="running"&&key=="pierre"&&launchTime>1365000000000`
 
-- `s`/`sort`: OGNL expression used as a `Comparable` to sort (default to no ordering). Example: `daysOld`.
+- `s`/`sort`: OGNL expression used as a `Comparable` to sort (default to no ordering).
+Example: `daysOld`.
 
 - `l`/`limit`: maximum number of records to return (defaults to none). Example: `10`.
 
@@ -56,7 +59,7 @@ Search tables in DynamoDB.
 Optional parameters:
 
 - `q` / `query`: OGNL expression used to filter. Example:
-  - `id > 100 && readCapacityUnits > 10`
+  - `id>100&&readCapacityUnits>10`
 - `s` / `sort`: OGNL expression used as a ``Comparable`` to sort (default to no ordering). Example:  
   - `s=itemCount`
 - `l` / `limit`: maximum number of records to return. Example:
@@ -65,7 +68,8 @@ Optional parameters:
   - `f=tableName,tableStatus`
   - `f=tableName`
 
-Sample response (the ``readCapacityUnits`` and ``writeCapacityUnits`` are pulled out of ``provisionedThroughput`` which allows users to sort with these attributes):
+Attributes(``readCapacityUnits`` and ``writeCapacityUnits`` are pulled out of
+  ``provisionedThroughput`` which allows users to sort with these attributes):
 
 ```
 {
@@ -80,13 +84,31 @@ Sample response (the ``readCapacityUnits`` and ``writeCapacityUnits`` are pulled
   "tableSizeBytes": 0,
   "itemCount": 0,
   "tableArn": "arn:aws:dynamodb:us-east-1:xxxxx:table/user_table,
-  "provisionedThroughput": "{NumberOfDecreasesToday: 0,ReadCapacityUnits: 1,WriteCapacityUnits: 1}"
+  "provisionedThroughput": "{NumberOfDecreasesToday: 0,ReadCapacityUnits: 1,
+    WriteCapacityUnits: 1}"
 }
 ```
 
 Sample query: show readCapacityUnits and tableName of all tables sorted by readCapacity:
-``/dynamo?s=readCapacityUnits&&f=readCapacityUnits,tableName``
+``/dynamo?s=readCapacityUnits&&f=readCapacityUnits,tableName&&l=3``
 
+Sample response:
+```
+[
+  {
+    tableName: "user_join_test",
+    readCapacityUnits: 1
+  },
+  {
+    tableName: "kincaidscore",
+    readCapacityUnits: 2
+  },
+  {
+    tableName: "two_factor",
+    readCapacityUnits: 3
+  }
+]
+```
 
 
 ### /dynamo/all  ###

--- a/README.md
+++ b/README.md
@@ -43,51 +43,33 @@ Optional parameters:
   - `az,type`
   - `id,publicIP,launchTime`
 
+### /ec2/all ###
+Search all ec2 instances.
+
+### /rds/all ###
+Search all RDS resources.
+
 ### /dynamo ###
 
-- `/dynamo/all`
-- `q` / `query`
-- `s` / `sort`
-    - `/dynamo?s=itemCount`
-- `l` / `limit`
-    - `/dynamo?l=10`
-- `f` / `field`
-    * `/dynamo?f=tableName,tableStatus`
-    * tableName
-    * attributeDefinitions
-    * tableStatus
-    * keySchema
-    * creationDateTime
-    * numberOfDecreasesToday
-    * readCapacityUnits
-    * writeCapacityUnits
-    * tableSizeBytes
-    * itemCount
-    * tableArn
-    * provisionedThroughput
+Search tables in DynamoDB.
 
-  Response
-  ```json
-  {
-      "tableName": "user_join_test",
-      "attributeDefinitions": "[{AttributeName: foo,AttributeType: S}]",
-      "tableStatus": "ACTIVE",
-      "keySchema": "[{AttributeName: foo,KeyType: HASH}]",
-      "creationDateTime": 1442960756398,
-      "numberOfDecreasesToday": 0,
-      "readCapacityUnits": 1,
-      "writeCapacityUnits": 1,
-      "tableSizeBytes": 0,
-      "itemCount": 0,
-      "tableArn": "arn:aws:dynamodb:us-east-1:172631448019:table/user_join_test",
-      "provisionedThroughput": "{NumberOfDecreasesToday: 0,ReadCapacityUnits: 1,WriteCapacityUnits: 1}"
-  }
-  ```
+Optional parameters:
 
-  ```
-  http://10.1.148.94:8080/dynamo?s=readCapacityUnits&&f=readCapacityUnits,tableName
-  ```
+- `q` / `query`: OGNL expression used to filter. Example:
+  - `id > 100 && readCapacityUnits > 10`
+- `s` / `sort`: OGNL expression used as a ``Comparable`` to sort (default to no ordering). Example:  
+  - `s=itemCount`
+- `l` / `limit`: maximum number of records to return. Example:
+  - `l=10`
+- `f` / `field`: comma-separated list of fields to display(defaults to all). Examples:
+  - `f=tableName,tableStatus`
+  - `f=tableName`
 
+Example: show readCapacityUnits and tableName of all tables sorted by readCapacity. 
+``/dynamo?s=readCapacityUnits&&f=readCapacityUnits,tableName``
+
+### /dynamo/all  ###
+Search all tables in DynamoDB.
 
 ### /iam ###
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,29 @@ Optional parameters:
   - `f=tableName,tableStatus`
   - `f=tableName`
 
-Example: show readCapacityUnits and tableName of all tables sorted by readCapacity. 
+Sample response (the ``readCapacityUnits`` and ``writeCapacityUnits`` are pulled out of ``provisionedThroughput`` which allows users to sort with these attributes):
+
+```
+{
+  "tableName": "user_table",
+  "attributeDefinitions": "[{AttributeName: foo,AttributeType: S}]",
+  "tableStatus": "ACTIVE",
+  "keySchema": "[{AttributeName: foo,KeyType: HASH}]",
+  "creationDateTime": 14887890,
+  "numberOfDecreasesToday": 0,
+  "readCapacityUnits": 1,
+  "writeCapacityUnits": 1,
+  "tableSizeBytes": 0,
+  "itemCount": 0,
+  "tableArn": "arn:aws:dynamodb:us-east-1:xxxxx:table/user_table,
+  "provisionedThroughput": "{NumberOfDecreasesToday: 0,ReadCapacityUnits: 1,WriteCapacityUnits: 1}"
+}
+```
+
+Sample query: show readCapacityUnits and tableName of all tables sorted by readCapacity:
 ``/dynamo?s=readCapacityUnits&&f=readCapacityUnits,tableName``
+
+
 
 ### /dynamo/all  ###
 Search all tables in DynamoDB.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.airbnb.billow</groupId>
     <artifactId>billow</artifactId>
-    <version>2.4</version>
+    <version>2.5</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/airbnb/billow/AWSDatabase.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabase.java
@@ -1,5 +1,17 @@
 package com.airbnb.billow;
 
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.dynamodbv2.document.DynamoDB;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.amazonaws.services.dynamodbv2.document.TableCollection;
+import com.amazonaws.services.dynamodbv2.model.ListTablesResult;
 import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.Reservation;
@@ -12,23 +24,15 @@ import com.amazonaws.services.identitymanagement.model.ListUsersResult;
 import com.amazonaws.services.identitymanagement.model.User;
 import com.amazonaws.services.rds.AmazonRDSClient;
 import com.amazonaws.services.rds.model.DBInstance;
-import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
-import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
-import com.amazonaws.services.rds.model.ListTagsForResourceRequest;
-import com.amazonaws.services.rds.model.ListTagsForResourceResult;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
-import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Data
 public class AWSDatabase {
     private final ImmutableMultimap<String, EC2Instance> ec2Instances;
-    private final ImmutableMultimap<String, RDSInstance> rdsInstances;
+    private final ImmutableMultimap<String, DynamoTable> dynamoTables;
+    // private final ImmutableMultimap<String, RDSInstance> rdsInstances;
     private final ImmutableMultimap<String, SecurityGroup> ec2SGs;
     private final ImmutableList<IAMUserWithKeys> iamUsers;
     private final long timestamp;
@@ -36,12 +40,14 @@ public class AWSDatabase {
 
     AWSDatabase(final Map<String, AmazonEC2Client> ec2Clients,
                 final Map<String, AmazonRDSClient> rdsClients,
+                final Map<String, AmazonDynamoDBClient> dynamoClients,
                 final AmazonIdentityManagementClient iamClient) {
-        this(ec2Clients, rdsClients, iamClient, null);
+        this(ec2Clients, rdsClients, dynamoClients, iamClient, null);
     }
 
     AWSDatabase(final Map<String, AmazonEC2Client> ec2Clients,
                 final Map<String, AmazonRDSClient> rdsClients,
+                final Map<String, AmazonDynamoDBClient> dynamoClients,
                 final AmazonIdentityManagementClient iamClient,
                 final String configAWSAccountNumber) {
         timestamp = System.currentTimeMillis();
@@ -49,13 +55,36 @@ public class AWSDatabase {
 
         log.info("Getting EC2 instances");
         final ImmutableMultimap.Builder<String, EC2Instance> ec2InstanceBuilder = new ImmutableMultimap.Builder<String, EC2Instance>();
-
+        final ImmutableMultimap.Builder<String, DynamoTable> dynamoTableBuilder = new ImmutableMultimap.Builder<>();
         if (configAWSAccountNumber == null) {
             awsAccountNumber = "";
         } else {
             log.info("using account number '{}' from config", configAWSAccountNumber);
             awsAccountNumber = configAWSAccountNumber;
         }
+
+        /**
+         * DynamoDB Tables
+         */
+
+        for (Map.Entry<String, AmazonDynamoDBClient> clientPair : dynamoClients.entrySet()) {
+            final String regionName = clientPair.getKey();
+            final AmazonDynamoDBClient client = clientPair.getValue();
+            final DynamoDB dynamoDB = new DynamoDB(client);
+            TableCollection<ListTablesResult> tables = dynamoDB.listTables();
+            Iterator<Table> iterator = tables.iterator();
+
+            log.info("Getting DynamoDB from {}", regionName);
+            int cnt = 0;
+            while (iterator.hasNext()) {
+                Table table = iterator.next();
+                dynamoTableBuilder.putAll(regionName, new DynamoTable(table));
+                cnt++;
+            }
+
+            log.debug("Found {} dynamodbs in {}", cnt, regionName);
+        }
+        this.dynamoTables = dynamoTableBuilder.build();
 
         /*
          * EC2 Instances
@@ -124,7 +153,7 @@ public class AWSDatabase {
         /*
          * RDS Instances
          */
-
+        /**
         log.info("Getting RDS instances");
         final ImmutableMultimap.Builder<String, RDSInstance> rdsBuilder = new ImmutableMultimap.Builder<String, RDSInstance>();
 
@@ -155,6 +184,7 @@ public class AWSDatabase {
             } while (result.getMarker() != null);
         }
         this.rdsInstances = rdsBuilder.build();
+        **/
 
         log.info("Done building AWS DB");
     }

--- a/src/main/java/com/airbnb/billow/AWSDatabase.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabase.java
@@ -178,7 +178,7 @@ public class AWSDatabase {
                 for (DBInstance instance : instances) {
                     ListTagsForResourceRequest tagsRequest = new ListTagsForResourceRequest()
                             .withResourceName(rdsARN(regionName, awsAccountNumber, instance));
-                    log.info("resource name {}",tagsRequest.getResourceName());
+
                     ListTagsForResourceResult tagsResult = client.listTagsForResource(tagsRequest);
 
                     rdsBuilder.putAll(regionName, new RDSInstance(instance, tagsResult.getTagList()));
@@ -188,7 +188,6 @@ public class AWSDatabase {
             } while (result.getMarker() != null);
         }
         this.rdsInstances = rdsBuilder.build();
-
 
         log.info("Done building AWS DB");
     }

--- a/src/main/java/com/airbnb/billow/AWSDatabase.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabase.java
@@ -24,6 +24,10 @@ import com.amazonaws.services.identitymanagement.model.ListUsersResult;
 import com.amazonaws.services.identitymanagement.model.User;
 import com.amazonaws.services.rds.AmazonRDSClient;
 import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.amazonaws.services.rds.model.ListTagsForResourceRequest;
+import com.amazonaws.services.rds.model.ListTagsForResourceResult;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 
@@ -32,7 +36,7 @@ import com.google.common.collect.ImmutableMultimap;
 public class AWSDatabase {
     private final ImmutableMultimap<String, EC2Instance> ec2Instances;
     private final ImmutableMultimap<String, DynamoTable> dynamoTables;
-    // private final ImmutableMultimap<String, RDSInstance> rdsInstances;
+    private final ImmutableMultimap<String, RDSInstance> rdsInstances;
     private final ImmutableMultimap<String, SecurityGroup> ec2SGs;
     private final ImmutableList<IAMUserWithKeys> iamUsers;
     private final long timestamp;
@@ -153,7 +157,7 @@ public class AWSDatabase {
         /*
          * RDS Instances
          */
-        /**
+
         log.info("Getting RDS instances");
         final ImmutableMultimap.Builder<String, RDSInstance> rdsBuilder = new ImmutableMultimap.Builder<String, RDSInstance>();
 
@@ -174,7 +178,7 @@ public class AWSDatabase {
                 for (DBInstance instance : instances) {
                     ListTagsForResourceRequest tagsRequest = new ListTagsForResourceRequest()
                             .withResourceName(rdsARN(regionName, awsAccountNumber, instance));
-
+                    log.info("resource name {}",tagsRequest.getResourceName());
                     ListTagsForResourceResult tagsResult = client.listTagsForResource(tagsRequest);
 
                     rdsBuilder.putAll(regionName, new RDSInstance(instance, tagsResult.getTagList()));
@@ -184,7 +188,7 @@ public class AWSDatabase {
             } while (result.getMarker() != null);
         }
         this.rdsInstances = rdsBuilder.build();
-        **/
+
 
         log.info("Done building AWS DB");
     }

--- a/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
@@ -1,15 +1,5 @@
 package com.airbnb.billow;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.retry.RetryPolicy;
-import com.amazonaws.services.ec2.AmazonEC2Client;
-import com.amazonaws.services.ec2.model.Region;
-import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient;
-import com.amazonaws.services.rds.AmazonRDSClient;
-import com.codahale.metrics.health.HealthCheck;
-import com.google.common.collect.Maps;
-import com.typesafe.config.Config;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -17,10 +7,25 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.retry.RetryPolicy;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.Region;
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient;
+import com.amazonaws.services.rds.AmazonRDSClient;
+import com.amazonaws.services.sqs.AmazonSQSClient;
+import com.codahale.metrics.health.HealthCheck;
+import com.google.common.collect.Maps;
+import com.typesafe.config.Config;
+
 @Slf4j
 public class AWSDatabaseHolder {
     private final Map<String, AmazonEC2Client> ec2Clients;
     private final Map<String, AmazonRDSClient> rdsClients;
+    private final Map<String, AmazonSQSClient> sqsClients;
+    private final Map<String, AmazonDynamoDBClient> dynamoDBClients;
     private final AmazonIdentityManagementClient iamClient;
     @Getter
     private AWSDatabase current;
@@ -38,16 +43,23 @@ public class AWSDatabaseHolder {
         final AmazonEC2Client bootstrapEC2Client = new AmazonEC2Client(awsCredentialsProviderChain);
         ec2Clients = Maps.newHashMap();
         rdsClients = Maps.newHashMap();
+        dynamoDBClients = Maps.newHashMap();
+        sqsClients = Maps.newHashMap();
 
-        final List<Region> regions = bootstrapEC2Client.describeRegions().getRegions();
-        for (Region region : regions) {
+        final List<Region> ec2Regions = bootstrapEC2Client.describeRegions().getRegions();
+        for (Region region : ec2Regions) {
             final String regionName = region.getRegionName();
             final String endpoint = region.getEndpoint();
-            log.debug("Adding region {}", region);
+            log.debug("Adding ec2 region {}", region);
 
             final AmazonEC2Client ec2Client = new AmazonEC2Client(awsCredentialsProviderChain, clientConfig);
             ec2Client.setEndpoint(endpoint);
             ec2Clients.put(regionName, ec2Client);
+
+            final AmazonDynamoDBClient dynamoDBClient =
+                new AmazonDynamoDBClient(awsCredentialsProviderChain, clientConfig);
+            dynamoDBClient.setEndpoint(endpoint.replaceFirst("ec2\\.", "dynamodb."));
+            dynamoDBClients.put(regionName, dynamoDBClient);
 
             final AmazonRDSClient rdsClient = new AmazonRDSClient(awsCredentialsProviderChain, clientConfig);
             rdsClient.setEndpoint(endpoint.replaceFirst("ec2\\.", "rds."));
@@ -66,7 +78,7 @@ public class AWSDatabaseHolder {
     }
 
     public void rebuild() {
-        current = new AWSDatabase(ec2Clients, rdsClients, iamClient, awsAccountNumber);
+        current = new AWSDatabase(ec2Clients, rdsClients, dynamoDBClients, iamClient, awsAccountNumber);
     }
 
     public HealthCheck.Result healthy() {

--- a/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
@@ -15,7 +15,6 @@ import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.Region;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient;
 import com.amazonaws.services.rds.AmazonRDSClient;
-import com.amazonaws.services.sqs.AmazonSQSClient;
 import com.codahale.metrics.health.HealthCheck;
 import com.google.common.collect.Maps;
 import com.typesafe.config.Config;
@@ -24,7 +23,6 @@ import com.typesafe.config.Config;
 public class AWSDatabaseHolder {
     private final Map<String, AmazonEC2Client> ec2Clients;
     private final Map<String, AmazonRDSClient> rdsClients;
-    private final Map<String, AmazonSQSClient> sqsClients;
     private final Map<String, AmazonDynamoDBClient> dynamoDBClients;
     private final AmazonIdentityManagementClient iamClient;
     @Getter
@@ -44,7 +42,6 @@ public class AWSDatabaseHolder {
         ec2Clients = Maps.newHashMap();
         rdsClients = Maps.newHashMap();
         dynamoDBClients = Maps.newHashMap();
-        sqsClients = Maps.newHashMap();
 
         final List<Region> ec2Regions = bootstrapEC2Client.describeRegions().getRegions();
         for (Region region : ec2Regions) {

--- a/src/main/java/com/airbnb/billow/DynamoTable.java
+++ b/src/main/java/com/airbnb/billow/DynamoTable.java
@@ -1,0 +1,62 @@
+package com.airbnb.billow;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.amazonaws.services.ec2.model.GroupIdentifier;
+import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.StateReason;
+import com.amazonaws.services.ec2.model.Tag;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+
+@JsonFilter(DynamoTable.Table_FILTER)
+public class DynamoTable {
+    public static final String Table_FILTER = "TableFilter";
+
+    @Getter
+    private final String tableName;
+    @Getter
+    private final String attributeDefinitions;
+    @Getter
+    private final String tableStatus;
+    @Getter
+    private final String keySchema;
+    @Getter
+    private final DateTime creationDateTime;
+    @Getter
+    private final long numberOfDecreasesToday;
+    @Getter
+    private final long readCapacityUnits;
+    @Getter
+    private final long writeCapacityUnits;
+    @Getter
+    private final long tableSizeBytes;
+    @Getter
+    private final long itemCount;
+    @Getter
+    private final String tableArn;
+    @Getter
+    private final String provisionedThroughput;
+
+    public DynamoTable(Table table) {
+        tableName = table.getTableName();
+        attributeDefinitions = table.describe().getAttributeDefinitions().toString();
+        tableStatus = table.describe().getTableStatus();
+        keySchema = table.describe().getKeySchema().toString();
+        creationDateTime = new DateTime(table.describe().getCreationDateTime());
+        numberOfDecreasesToday = table.describe().getProvisionedThroughput().getNumberOfDecreasesToday();
+        readCapacityUnits = table.describe().getProvisionedThroughput().getReadCapacityUnits();
+        writeCapacityUnits = table.describe().getProvisionedThroughput().getWriteCapacityUnits();
+        tableSizeBytes = table.describe().getTableSizeBytes();
+        itemCount = table.describe().getItemCount();
+        tableArn = table.describe().getTableArn();
+        provisionedThroughput = table.describe().getProvisionedThroughput().toString();
+    }
+}

--- a/src/main/java/com/airbnb/billow/Handler.java
+++ b/src/main/java/com/airbnb/billow/Handler.java
@@ -102,7 +102,7 @@ public class Handler extends AbstractHandler {
                     handleSimpleRequest(response, current.getEc2Instances());
                     break;
                 case "/rds/all":
-                    // handleSimpleRequest(response, current.getRdsInstances());
+                    handleSimpleRequest(response, current.getRdsInstances());
                     break;
                 case "/ec2/sg":
                     handleSimpleRequest(response, current.getEc2SGs());

--- a/src/main/java/com/airbnb/billow/Handler.java
+++ b/src/main/java/com/airbnb/billow/Handler.java
@@ -117,7 +117,7 @@ public class Handler extends AbstractHandler {
                     handleSimpleRequest(response, current.getIamUsers());
                     break;
                 case "/dynamo":
-                    handleComlexDynamo(response, paramMap, current);
+                    handleComplexDynamo(response, paramMap, current);
                     break;
                 default:
                     response.setStatus(HttpServletResponse.SC_NOT_FOUND);
@@ -138,7 +138,7 @@ public class Handler extends AbstractHandler {
         }
     }
 
-    private void handleComlexDynamo(HttpServletResponse response,
+    private void handleComplexDynamo(HttpServletResponse response,
                                     Map<String, String[]> params,
                                     AWSDatabase db) {
         final String query = getQuery(params);

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -12,9 +12,13 @@ billow {
         # How many retries to make for failing requests (uses AWS exponential backoff)
         maxErrorRetry = 10
 
-        # AWS account ID
-        accountNumber = 123456789012
 
+
+        # AWS account
+        # The account and Ids are used for local development and testing and should be
+        # commented out when deployed inside airbnb.
+
+        # accountNumber = 123456789012
         # accessKeyId = AK47
         # secretKeyId = OMGsoSecret
     }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -14,11 +14,14 @@ billow {
 
 
 
-        # AWS account
-        # The account and Ids are used for local development and testing and should be
-        # commented out when deployed inside airbnb.
+        # The AWS Account Number and Access Key fields are commented out because we
+        # prefer the use of IAM Roles in productions. These fields are useful for
+        # local development.
 
+        # AWS Account Number
         # accountNumber = 123456789012
+
+        # AWS Access Key
         # accessKeyId = AK47
         # secretKeyId = OMGsoSecret
     }


### PR DESCRIPTION
Add DynamoDB api in billow to support table level queries. The DynamoDB API supports OGNL queries, sort, limit and filed parameters which is the same as EC2. 
* I split the table description into serval attributes including: ``tableStatus, ableName, attributeDefinitions, keySchema, creationDateTime, tableSizeBytes, itemCount, tableArn and provisionedThroughput``. 

* Also `readCapacityUnits` and `writeCapacityUnits` are separated from `provisionedThroughput` which originally is a string that contains several throughput info. Users now can query/sort with read/write capacity.

@wyao 
@joeyparsons
@schleyfox