### PR TITLE
Add iamInstanceProfile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Fields of ec2 instances:
       name: "Open Web Server"
     }
   ],
+  iamInstanceProfile: "arn:aws:iam::123456789012:instance-profile/sample-Iamrole",
   daysOld: 1352.2294
 }
 ```

--- a/src/main/java/com/airbnb/billow/AWSDatabase.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabase.java
@@ -207,7 +207,7 @@ public class AWSDatabase {
          */
 
         log.info("Getting IAM keys");
-        final ImmutableList.Builder<IAMUserWithKeys> usersBuilder = new ImmutableList.Builder<IAMUserWithKeys>();
+        final ImmutableList.Builder<IAMUserWithKeys> usersBuilder = new ImmutableList.Builder<>();
 
         final ListUsersRequest listUsersRequest = new ListUsersRequest();
         ListUsersResult listUsersResult;

--- a/src/main/java/com/airbnb/billow/EC2Instance.java
+++ b/src/main/java/com/airbnb/billow/EC2Instance.java
@@ -79,6 +79,8 @@ public class EC2Instance {
     private final DateTime launchTime;
     @Getter
     private final List<SecurityGroup> securityGroups;
+    @Getter
+    private final String iamInstanceProfile;
 
     public EC2Instance(Instance instance) {
         this.id = instance.getInstanceId();
@@ -108,6 +110,12 @@ public class EC2Instance {
         this.virtualizationType = instance.getVirtualizationType();
         this.sourceDestCheck = instance.getSourceDestCheck();
         this.launchTime = new DateTime(instance.getLaunchTime());
+
+        if (instance.getIamInstanceProfile() != null) {
+            this.iamInstanceProfile = instance.getIamInstanceProfile().getArn().toString();
+        } else {
+            this.iamInstanceProfile = null;
+        }
 
         final StateReason stateReason = instance.getStateReason();
         if (stateReason != null)


### PR DESCRIPTION
Changed it such that Billow can return the iam instance profile names. This is useful for seeing what iam role each ec2 instance has.
@tuckerman