### PR TITLE
Add socketTimeout option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.airbnb.billow</groupId>
     <artifactId>billow</artifactId>
-    <version>2.14</version>
+    <version>2.15</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
@@ -41,6 +41,7 @@ public class AWSDatabaseHolder {
 
         final ClientConfiguration clientConfig = new ClientConfiguration();
         clientConfig.setRetryPolicy(new RetryPolicy(null, null, config.getInt("maxErrorRetry"), true));
+        clientConfig.setSocketTimeout(config.getInt("socketTimeout") * 1000);
 
         final AmazonEC2Client bootstrapEC2Client = new AmazonEC2Client(awsCredentialsProviderChain);
         ec2Clients = Maps.newHashMap();

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -12,7 +12,8 @@ billow {
         # How many retries to make for failing requests (uses AWS exponential backoff)
         maxErrorRetry = 10
 
-
+        # Timeout for HTTP socket in seconds
+        socketTimeout = 120
 
         # The AWS Account Number and Access Key fields are commented out because we
         # prefer the use of IAM Roles in productions. These fields are useful for


### PR DESCRIPTION
Billow runs timeout and fail if there is a high number of EC2 reservations due to the default value of 60 second.

We also add a socketTimeout configuration value to allow us to modify the value via JVM options via the -Dbillow.aws.socketTimeout value.