### PR TITLE
Add support to communicate with AWS China

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dependency-reduced-pom.xml
+target/
+application.properties

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.airbnb.billow</groupId>
     <artifactId>billow</artifactId>
-    <version>2.17</version>
+    <version>2.18</version>
 
     <licenses>
         <license>
@@ -31,15 +31,15 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <aws.version>1.10.31</aws.version>
+        <aws.version>1.11.548</aws.version>
         <lombok.version>1.12.6</lombok.version>
         <guava.version>16.0.1</guava.version>
-        <jetty.version>9.1.3.v20140225</jetty.version>
+        <jetty.version>9.3.24.v20180605</jetty.version>
         <config.version>1.2.0</config.version>
         <metrics.version>3.0.2</metrics.version>
         <slf4j.version>1.7.6</slf4j.version>
         <logback.version>1.1.1</logback.version>
-        <jackson.version>2.2.3</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
         <joda-time.version>2.3</joda-time.version>
         <ognl.version>3.0.8</ognl.version>
         <quartz.version>2.2.1</quartz.version>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -25,5 +25,15 @@ billow {
         # AWS Access Key
         # accessKeyId = AK47
         # secretKeyId = OMGsoSecret
+
+        # AWS ARN Partition
+        # arnPartition = aws
+
+        ec2Enabled = true
+        rdsEnabled = true
+        dynamodbEnabled = true
+        sqsEnabled = true
+        elasticacheEnabled = true
+        elasticsearchEnabled = true
     }
 }


### PR DESCRIPTION
Various changes:

- Adding support for configuring the ARN partition name, to support AWS China with uses `aws-cn` ARN partition name.
- Updating AWS jar version
- Updating AWS client object types in order to use auth credentials from `~/.aws/credentials`
- Allow disabling specific AWS service types from being queried
- Updating Jackson version to support new AWS jar version

@darnaut 
