### PR TITLE
[Billow] Add more elasticsearch metadata to ES responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dependency-reduced-pom.xml
 target/
 application.properties
+.idea
+billow.iml

--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ We use Typesafe's config.
 Look at the `reference.conf` resource for the available parameters.
 To get quickly started, pass the following parameters to the JVM: `-Dbillow.aws.accessKeyId=HELLO -Dbillow.aws.secretKeyId=WoRld`.
 
+Note: For local development, ensure that you remove the `profile ` prefix from
+profile names in `~/.aws/config` and `~/.aws/credentials` if you are using
+those. This is due to a mis-match in what the AWS Python SDK expects and what this
+version of the Java SDK expects. [More details here.](https://github.com/aws/aws-sdk-java/issues/1707)
+
 ## Monitoring guide ##
 
 We expose an admin port offering metrics and health checks.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.airbnb.billow</groupId>
     <artifactId>billow</artifactId>
-    <version>2.18</version>
+    <version>2.19</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/airbnb/billow/AWSDatabase.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabase.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.elasticache.model.DescribeReplicationGroupsResult;
 import com.amazonaws.services.elasticache.model.NodeGroup;
 import com.amazonaws.services.elasticache.model.NodeGroupMember;
 import com.amazonaws.services.elasticache.model.ReplicationGroup;
+import com.amazonaws.services.elasticsearch.model.DescribeElasticsearchDomainRequest;
+import com.amazonaws.services.elasticsearch.model.DescribeElasticsearchDomainResult;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
@@ -211,7 +213,12 @@ public class AWSDatabase {
                 ListTagsRequest listTagsRequest = new ListTagsRequest();
                 listTagsRequest.setARN(elasticsearchARN(awsARNPartition, regionName, awsAccountNumber, domainInfo.getDomainName()));
                 ListTagsResult tagList = client.listTags(listTagsRequest);
-                elasticsearchClusterBuilder.putAll(regionName, new ElasticsearchCluster(domainInfo, tagList.getTagList()));
+
+                DescribeElasticsearchDomainRequest describeDomainRequest = new DescribeElasticsearchDomainRequest();
+                describeDomainRequest.setDomainName(domainInfo.getDomainName());
+                DescribeElasticsearchDomainResult describeDomainResult = client.describeElasticsearchDomain(describeDomainRequest);
+
+                elasticsearchClusterBuilder.putAll(regionName, new ElasticsearchCluster(describeDomainResult.getDomainStatus(), tagList.getTagList()));
             }
             log.debug("Found {} Elasticsearch domains in {}", domainInfoList.size(), regionName);
 

--- a/src/main/java/com/airbnb/billow/ElasticsearchCluster.java
+++ b/src/main/java/com/airbnb/billow/ElasticsearchCluster.java
@@ -1,25 +1,51 @@
 package com.airbnb.billow;
 
+import com.amazonaws.services.elasticsearch.model.ElasticsearchClusterConfig;
+import com.amazonaws.services.elasticsearch.model.ElasticsearchDomainStatus;
+import com.amazonaws.services.elasticsearch.model.Tag;
 import lombok.Getter;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.services.elasticsearch.model.DomainInfo;
-import com.amazonaws.services.elasticsearch.model.Tag;
-
 public class ElasticsearchCluster {
   @Getter
   private final String domainName;
   @Getter
   private final Map<String, String> tags;
+  @Getter
+  private final String version;
+  @Getter
+  private final String instanceType;
+  @Getter
+  private final int instanceCount;
+  @Getter
+  private final Map<String, String> endpoints;
+  @Getter
+  private final boolean dedicatedMasterEnabled;
+  @Getter
+  private final boolean zoneAwarenessEnabled;
+  @Getter
+  private final String dedicatedMasterType;
+  @Getter
+  private final int dedicatedMasterCount;
 
-  public ElasticsearchCluster(DomainInfo domainInfo, List<Tag> tagList) {
-      this.domainName = domainInfo.getDomainName();
-      this.tags = new HashMap<>(tagList.size());
-      for(Tag tag : tagList) {
-        this.tags.put(tag.getKey(), tag.getValue());
-      }
+  public ElasticsearchCluster(ElasticsearchDomainStatus domainStatus, List<Tag> tagList) {
+    this.domainName = domainStatus.getDomainName();
+    this.tags = new HashMap<>(tagList.size());
+    for(Tag tag : tagList) {
+      this.tags.put(tag.getKey(), tag.getValue());
+    }
+    this.version = domainStatus.getElasticsearchVersion();
+    this.endpoints = domainStatus.getEndpoints();
+
+    ElasticsearchClusterConfig esConfig = domainStatus.getElasticsearchClusterConfig();
+    this.instanceType = esConfig.getInstanceType();
+    this.instanceCount = esConfig.getInstanceCount();
+    this.dedicatedMasterEnabled = esConfig.getDedicatedMasterEnabled();
+    this.zoneAwarenessEnabled = esConfig.getZoneAwarenessEnabled();
+    this.dedicatedMasterType = esConfig.getDedicatedMasterType();
+    this.dedicatedMasterCount = esConfig.getDedicatedMasterCount();
   }
 }


### PR DESCRIPTION
The storage foundation team is adding Elasticsearch data to Porter, we need to surface helpful metadata via billow. May issue a follow-up PR to add more data if we find that this leaves something important out. Tested locally via Postman

cc @zuofei 