### PR TITLE
Track database age and failures in metrics, send metrics to Datadog

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,12 @@
             <artifactId>quartz</artifactId>
             <version>${quartz.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.coursera</groupId>
+            <artifactId>dropwizard-metrics-datadog</artifactId>
+            <version>1.1.13</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.airbnb.billow</groupId>
     <artifactId>billow</artifactId>
-    <version>2.20</version>
+    <version>2.21</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/airbnb/billow/AWSDatabase.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabase.java
@@ -122,7 +122,6 @@ public class AWSDatabase {
 
         final ListUsersRequest listUsersRequest = new ListUsersRequest();
         ListUsersResult listUsersResult;
-        /*
         do {
             log.debug("Performing IAM request: {}", listUsersRequest);
             listUsersResult = iamClient.listUsers(listUsersRequest);
@@ -142,8 +141,7 @@ public class AWSDatabase {
             }
             listUsersRequest.setMarker(listUsersResult.getMarker());
         } while (listUsersResult.isTruncated());
-        TODO: uncomment
-         */
+
         this.iamUsers = usersBuilder.build();
 
         /*

--- a/src/main/java/com/airbnb/billow/AWSDatabase.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabase.java
@@ -122,6 +122,7 @@ public class AWSDatabase {
 
         final ListUsersRequest listUsersRequest = new ListUsersRequest();
         ListUsersResult listUsersResult;
+        /*
         do {
             log.debug("Performing IAM request: {}", listUsersRequest);
             listUsersResult = iamClient.listUsers(listUsersRequest);
@@ -141,6 +142,8 @@ public class AWSDatabase {
             }
             listUsersRequest.setMarker(listUsersResult.getMarker());
         } while (listUsersResult.isTruncated());
+        TODO: uncomment
+         */
         this.iamUsers = usersBuilder.build();
 
         /*

--- a/src/main/java/com/airbnb/billow/AWSDatabase.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabase.java
@@ -122,6 +122,7 @@ public class AWSDatabase {
 
         final ListUsersRequest listUsersRequest = new ListUsersRequest();
         ListUsersResult listUsersResult;
+        /*
         do {
             log.debug("Performing IAM request: {}", listUsersRequest);
             listUsersResult = iamClient.listUsers(listUsersRequest);
@@ -140,8 +141,9 @@ public class AWSDatabase {
                 }
             }
             listUsersRequest.setMarker(listUsersResult.getMarker());
-        } while (listUsersResult.isTruncated());
+        } while (listUsersResult.isTruncated());        TODO uncomment */
         this.iamUsers = usersBuilder.build();
+
 
         /*
          * ElasticCache

--- a/src/main/java/com/airbnb/billow/AWSDatabase.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabase.java
@@ -141,7 +141,6 @@ public class AWSDatabase {
             }
             listUsersRequest.setMarker(listUsersResult.getMarker());
         } while (listUsersResult.isTruncated());
-
         this.iamUsers = usersBuilder.build();
 
         /*

--- a/src/main/java/com/airbnb/billow/AWSDatabase.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabase.java
@@ -122,7 +122,6 @@ public class AWSDatabase {
 
         final ListUsersRequest listUsersRequest = new ListUsersRequest();
         ListUsersResult listUsersResult;
-        /*
         do {
             log.debug("Performing IAM request: {}", listUsersRequest);
             listUsersResult = iamClient.listUsers(listUsersRequest);
@@ -141,7 +140,7 @@ public class AWSDatabase {
                 }
             }
             listUsersRequest.setMarker(listUsersResult.getMarker());
-        } while (listUsersResult.isTruncated());        TODO uncomment */
+        } while (listUsersResult.isTruncated());
         this.iamUsers = usersBuilder.build();
 
 

--- a/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
@@ -1,5 +1,6 @@
 package com.airbnb.billow;
 
+import com.codahale.metrics.MetricRegistry;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
@@ -1,5 +1,9 @@
 package com.airbnb.billow;
 
+import com.codahale.metrics.CachedGauge;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.sun.corba.se.impl.encoding.CachedCodeBase;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
@@ -1,9 +1,5 @@
 package com.airbnb.billow;
 
-import com.codahale.metrics.CachedGauge;
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.MetricRegistry;
-import com.sun.corba.se.impl.encoding.CachedCodeBase;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
@@ -1,6 +1,5 @@
 package com.airbnb.billow;
 
-import com.codahale.metrics.MetricRegistry;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/airbnb/billow/AWSDatabaseHolderRefreshJob.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabaseHolderRefreshJob.java
@@ -1,20 +1,33 @@
 package com.airbnb.billow;
 
+import com.codahale.metrics.Counter;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.SchedulerException;
 
 public class AWSDatabaseHolderRefreshJob implements Job {
-    public static final String DB_KEY = "db";
-    public static final String NAME = "dbRefresh";
+    public static final String DB_KEY              = "db";
+    public static final String FAILURE_COUNTER_KEY = "failure_counter";
+    public static final String SUCCESS_COUNTER_KEY = "success_counter";
+    public static final String NAME                = "dbRefresh";
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         try {
             ((AWSDatabaseHolder) context.getScheduler().getContext().get(DB_KEY)).rebuild();
+            increment(SUCCESS_COUNTER_KEY, context);
         } catch (SchedulerException e) {
+            increment(FAILURE_COUNTER_KEY, context);
             throw new JobExecutionException(e);
+        }
+    }
+
+    private void increment(String counterName, JobExecutionContext context) {
+        try {
+            ((Counter) context.getScheduler().getContext().get(counterName)).inc();
+        } catch (SchedulerException e) {
+            // do nothing, don't throw an error for metrics
         }
     }
 }

--- a/src/main/java/com/airbnb/billow/AWSDatabaseHolderRefreshJob.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabaseHolderRefreshJob.java
@@ -9,12 +9,14 @@ import org.quartz.SchedulerException;
 public class AWSDatabaseHolderRefreshJob implements Job {
     public static final String DB_KEY              = "db";
     public static final String FAILURE_COUNTER_KEY = "failure_counter";
+    public static final String START_COUNTER_KEY   = "start_counter";
     public static final String SUCCESS_COUNTER_KEY = "success_counter";
     public static final String NAME                = "dbRefresh";
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         try {
+            increment(START_COUNTER_KEY, context);
             ((AWSDatabaseHolder) context.getScheduler().getContext().get(DB_KEY)).rebuild();
             increment(SUCCESS_COUNTER_KEY, context);
         } catch (SchedulerException e) {

--- a/src/main/java/com/airbnb/billow/Main.java
+++ b/src/main/java/com/airbnb/billow/Main.java
@@ -1,6 +1,5 @@
 package com.airbnb.billow;
 
-import ch.qos.logback.classic.gaffer.GafferUtil;
 import com.codahale.metrics.CachedGauge;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;

--- a/src/main/java/com/airbnb/billow/Main.java
+++ b/src/main/java/com/airbnb/billow/Main.java
@@ -64,13 +64,15 @@ public class Main {
         };
 
         final String databaseAgeMetricName = MetricRegistry.name("billow", "database", "age", "ms");
-        final String jobFailureMetricName = MetricRegistry.name("billow", "database", "refresh", "failure");
-        final String jobSuccessMetricName = MetricRegistry.name("billow", "database", "refresh", "success");
+        final String jobFailureMetricName  = MetricRegistry.name("billow", "database", "refresh", "start");
+        final String jobStartMetricName    = MetricRegistry.name("billow", "database", "refresh", "failure");
+        final String jobSuccessMetricName  = MetricRegistry.name("billow", "database", "refresh", "success");
 
         metricRegistry.register(databaseAgeMetricName, cacheAgeGauge);
 
         final Scheduler scheduler = StdSchedulerFactory.getDefaultScheduler();
         scheduler.getContext().put(AWSDatabaseHolderRefreshJob.DB_KEY, dbHolder);
+        scheduler.getContext().put(AWSDatabaseHolderRefreshJob.START_COUNTER_KEY, metricRegistry.counter(jobStartMetricName));
         scheduler.getContext().put(AWSDatabaseHolderRefreshJob.FAILURE_COUNTER_KEY, metricRegistry.counter(jobFailureMetricName));
         scheduler.getContext().put(AWSDatabaseHolderRefreshJob.SUCCESS_COUNTER_KEY, metricRegistry.counter(jobSuccessMetricName));
         scheduler.start();

--- a/src/main/java/com/airbnb/billow/Main.java
+++ b/src/main/java/com/airbnb/billow/Main.java
@@ -62,10 +62,17 @@ public class Main {
                 return dbHolder.getCurrent().getAgeInMs();
             }
         };
-        metricRegistry.register("billow.database.age.ms", cacheAgeGauge);
+
+        final String databaseAgeMetricName = MetricRegistry.name("billow", "database", "age", "ms");
+        final String jobFailureMetricName = MetricRegistry.name("billow", "database", "refresh", "failure");
+        final String jobSuccessMetricName = MetricRegistry.name("billow", "database", "refresh", "success");
+
+        metricRegistry.register(databaseAgeMetricName, cacheAgeGauge);
 
         final Scheduler scheduler = StdSchedulerFactory.getDefaultScheduler();
         scheduler.getContext().put(AWSDatabaseHolderRefreshJob.DB_KEY, dbHolder);
+        scheduler.getContext().put(AWSDatabaseHolderRefreshJob.FAILURE_COUNTER_KEY, metricRegistry.counter(jobFailureMetricName));
+        scheduler.getContext().put(AWSDatabaseHolderRefreshJob.SUCCESS_COUNTER_KEY, metricRegistry.counter(jobSuccessMetricName));
         scheduler.start();
 
         final SimpleTrigger trigger = newTrigger().


### PR DESCRIPTION
In an attempt to speed up the load times, we should start out by measuring where we're at right now. This PR adds a metric which updates every minute tracking the age of the database in `ms`

## Reviewers

@jtai