### PR TITLE
[WIP] Populate each service's data separately

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,8 +207,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabaseHolder.java
@@ -1,5 +1,6 @@
 package com.airbnb.billow;
 
+import com.google.common.collect.ImmutableList;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -124,17 +125,76 @@ public class AWSDatabaseHolder {
         rebuild();
     }
 
+    /**
+     * Build a fresh version of the DB completely from scratch
+     */
     public void rebuild() {
         current = new AWSDatabase(
-            ec2Clients,
-            rdsClients,
-            dynamoDBClients,
-            sqsClients,
-            elasticacheClients,
-            elasticsearchClients,
-            iamClient,
-            awsAccountNumber,
-            awsARNPartition);
+                ec2Clients,
+                rdsClients,
+                dynamoDBClients,
+                sqsClients,
+                elasticacheClients,
+                elasticsearchClients,
+                iamClient,
+                awsAccountNumber,
+                awsARNPartition);
+    }
+
+    /**
+     * Incrementally refresh ec2 instance data
+     */
+    public void refreshEc2Instances() {
+        current.refreshEc2Instances(ec2Clients);
+    }
+
+    /**
+     * Incrementally refresh dyanmo data
+     */
+    public void refreshDynamoTables() {
+        current.refreshDynamoTables(dynamoDBClients);
+    }
+
+    /**
+     * Incrementally refresh rds instance data
+     */
+    public void refreshRdsInstances() {
+        current.refreshRdsInstances(rdsClients);
+    }
+
+    /**
+     * Incrementally refresh EC2 security group data
+     */
+    public void refreshEc2SGs() {
+        current.refreshEc2SGs(ec2Clients);
+    }
+
+    /**
+     * Incrementally refresh sqs data
+     */
+    public void refreshSqsQueues() {
+        current.refreshSqsQueues(sqsClients);
+    }
+
+    /**
+     * Incrementally refresh elasticache data
+     */
+    public void refreshElasticacheClusters() {
+        current.refreshElasticacheClusters(elasticacheClients);
+    }
+
+    /**
+     * Incrementally refresh IAM data
+     */
+    public void refreshIamUsers() {
+        current.refreshIamUsers(iamClient);
+    }
+
+    /**
+     * Incrementally refresh elasticsearch data
+     */
+    public void refreshElasticsearchClusters() {
+        current.refreshElasticsearchClusters(elasticsearchClients);
     }
 
     public HealthCheck.Result healthy() {

--- a/src/main/java/com/airbnb/billow/TimestampedData.java
+++ b/src/main/java/com/airbnb/billow/TimestampedData.java
@@ -1,0 +1,18 @@
+package com.airbnb.billow;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.function.Supplier;
+
+@Data
+@Slf4j
+public class TimestampedData<T> {
+    private final T data;
+    private final long timestamp;
+
+    public static <T> TimestampedData<T> withTimestamp(Supplier<T> supplier) {
+        long timestamp = System.currentTimeMillis();
+        return new TimestampedData<T>(supplier.get(), timestamp);
+    }
+}

--- a/src/main/java/com/airbnb/billow/jobs/BaseAWSDatabaseHolderRefreshJob.java
+++ b/src/main/java/com/airbnb/billow/jobs/BaseAWSDatabaseHolderRefreshJob.java
@@ -1,17 +1,17 @@
-package com.airbnb.billow;
+package com.airbnb.billow.jobs;
 
+import com.airbnb.billow.AWSDatabaseHolder;
 import com.codahale.metrics.Counter;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.SchedulerException;
 
-public class AWSDatabaseHolderRefreshJob implements Job {
+public abstract class BaseAWSDatabaseHolderRefreshJob implements Job {
     public static final String DB_KEY              = "db";
     public static final String FAILURE_COUNTER_KEY = "failure_counter";
     public static final String START_COUNTER_KEY   = "start_counter";
     public static final String SUCCESS_COUNTER_KEY = "success_counter";
-    public static final String NAME                = "dbRefresh";
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
@@ -24,6 +24,8 @@ public class AWSDatabaseHolderRefreshJob implements Job {
             throw new JobExecutionException(e);
         }
     }
+
+    abstract void refresh(AWSDatabaseHolder dbHolder);
 
     private void increment(String counterName, JobExecutionContext context) {
         try {

--- a/src/main/java/com/airbnb/billow/jobs/DynamoRefreshJob.java
+++ b/src/main/java/com/airbnb/billow/jobs/DynamoRefreshJob.java
@@ -1,0 +1,12 @@
+package com.airbnb.billow.jobs;
+
+import com.airbnb.billow.AWSDatabaseHolder;
+
+public class DynamoRefreshJob extends BaseAWSDatabaseHolderRefreshJob {
+    public static final String NAME = "dynamo_job";
+
+    @Override
+    void refresh(AWSDatabaseHolder dbHolder) {
+        dbHolder.refreshDynamoTables();
+    }
+}

--- a/src/main/java/com/airbnb/billow/jobs/Ec2InstanceRefreshJob.java
+++ b/src/main/java/com/airbnb/billow/jobs/Ec2InstanceRefreshJob.java
@@ -1,0 +1,12 @@
+package com.airbnb.billow.jobs;
+
+import com.airbnb.billow.AWSDatabaseHolder;
+
+public class Ec2InstanceRefreshJob extends BaseAWSDatabaseHolderRefreshJob {
+    public static final String NAME = "ec2_instance_job";
+
+    @Override
+    void refresh(AWSDatabaseHolder dbHolder) {
+        dbHolder.refreshEc2Instances();
+    }
+}

--- a/src/main/java/com/airbnb/billow/jobs/Ec2SGRefreshJob.java
+++ b/src/main/java/com/airbnb/billow/jobs/Ec2SGRefreshJob.java
@@ -1,0 +1,12 @@
+package com.airbnb.billow.jobs;
+
+import com.airbnb.billow.AWSDatabaseHolder;
+
+public class Ec2SGRefreshJob extends BaseAWSDatabaseHolderRefreshJob {
+    public static final String NAME = "ec2_sg_job";
+
+    @Override
+    void refresh(AWSDatabaseHolder dbHolder) {
+        dbHolder.refreshEc2SGs();
+    }
+}

--- a/src/main/java/com/airbnb/billow/jobs/ElasticacheRefreshJob.java
+++ b/src/main/java/com/airbnb/billow/jobs/ElasticacheRefreshJob.java
@@ -1,0 +1,12 @@
+package com.airbnb.billow.jobs;
+
+import com.airbnb.billow.AWSDatabaseHolder;
+
+public class ElasticacheRefreshJob extends BaseAWSDatabaseHolderRefreshJob {
+    public static final String NAME = "elasticache_job";
+
+    @Override
+    void refresh(AWSDatabaseHolder dbHolder) {
+        dbHolder.refreshElasticacheClusters();
+    }
+}

--- a/src/main/java/com/airbnb/billow/jobs/ElasticsearchRefreshJob.java
+++ b/src/main/java/com/airbnb/billow/jobs/ElasticsearchRefreshJob.java
@@ -1,0 +1,12 @@
+package com.airbnb.billow.jobs;
+
+import com.airbnb.billow.AWSDatabaseHolder;
+
+public class ElasticsearchRefreshJob extends BaseAWSDatabaseHolderRefreshJob {
+    public static final String NAME = "elasticsearch_job";
+
+    @Override
+    void refresh(AWSDatabaseHolder dbHolder) {
+        dbHolder.refreshElasticsearchClusters();
+    }
+}

--- a/src/main/java/com/airbnb/billow/jobs/IamRefreshJob.java
+++ b/src/main/java/com/airbnb/billow/jobs/IamRefreshJob.java
@@ -1,0 +1,12 @@
+package com.airbnb.billow.jobs;
+
+import com.airbnb.billow.AWSDatabaseHolder;
+
+public class IamRefreshJob extends BaseAWSDatabaseHolderRefreshJob {
+    public static final String NAME = "iam_job";
+
+    @Override
+    void refresh(AWSDatabaseHolder dbHolder) {
+        dbHolder.refreshIamUsers();
+    }
+}

--- a/src/main/java/com/airbnb/billow/jobs/RdsRefreshJob.java
+++ b/src/main/java/com/airbnb/billow/jobs/RdsRefreshJob.java
@@ -1,0 +1,12 @@
+package com.airbnb.billow.jobs;
+
+import com.airbnb.billow.AWSDatabaseHolder;
+
+public class RdsRefreshJob extends BaseAWSDatabaseHolderRefreshJob{
+    public static final String NAME = "rds_job";
+
+    @Override
+    void refresh(AWSDatabaseHolder dbHolder) {
+        dbHolder.refreshRdsInstances();
+    }
+}

--- a/src/main/java/com/airbnb/billow/jobs/SqsRefreshJob.java
+++ b/src/main/java/com/airbnb/billow/jobs/SqsRefreshJob.java
@@ -1,0 +1,12 @@
+package com.airbnb.billow.jobs;
+
+import com.airbnb.billow.AWSDatabaseHolder;
+
+public class SqsRefreshJob extends BaseAWSDatabaseHolderRefreshJob {
+    public static final String NAME = "sqs_job";
+
+    @Override
+    void refresh(AWSDatabaseHolder dbHolder) {
+        dbHolder.refreshSqsQueues();
+    }
+}


### PR DESCRIPTION
Right now, billow updates can take hours (or days) because of the size and rate limiting on our account. If a single stage in a job fails, the entire update fails and prevents any data from syncing.

This PR refactors the system so that each AWS service's data updates in its own job, so EC2 queries failing won't impact RDS data collection. A full initial build is still required on startup so we don't end up with an incomplete view of the data, but afterwards the services will update incrementally

## Reviewers

@jtai @erluoli