### PR TITLE
filter out non automated snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.airbnb.billow</groupId>
     <artifactId>billow</artifactId>
-    <version>2.25</version>
+    <version>2.26</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/airbnb/billow/AWSDatabase.java
+++ b/src/main/java/com/airbnb/billow/AWSDatabase.java
@@ -376,7 +376,8 @@ public class AWSDatabase {
                     if (RDSInstance.checkIfMaster(instance, instanceIdToCluster.get(instance.getDBInstanceIdentifier()))) {
                        if ("aurora".equals(instance.getEngine()) || "aurora-mysql".equals(instance.getEngine())) {
                            DescribeDBClusterSnapshotsRequest snapshotsRequest = new DescribeDBClusterSnapshotsRequest()
-                               .withDBClusterIdentifier(instance.getDBClusterIdentifier());
+                               .withDBClusterIdentifier(instance.getDBClusterIdentifier())
+                               .withSnapshotType("Automated");
                            DescribeDBClusterSnapshotsResult snapshotsResult = client.describeDBClusterSnapshots(snapshotsRequest);
                            for (DBClusterSnapshot s : snapshotsResult.getDBClusterSnapshots()) {
                                snapshots.add(s.getDBClusterSnapshotIdentifier());


### PR DESCRIPTION
the snapshot api only returns a certain number of snapshots and currently it is full of `awsbackup` ones. automated snapshots are the one we are using in all other places so filter out all non automated snapshots

@zuofei @erluoli 