### PR TITLE
Add configurationEndpoint field to EC response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.airbnb.billow</groupId>
     <artifactId>billow</artifactId>
-    <version>2.27</version>
+    <version>2.28</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/airbnb/billow/ElasticacheCluster.java
+++ b/src/main/java/com/airbnb/billow/ElasticacheCluster.java
@@ -72,6 +72,8 @@ public class ElasticacheCluster {
 
     public ElasticacheCluster(CacheCluster cacheCluster, NodeGroupMember nodeGroupMember, List<Tag> tagList) {
         this.cacheClusterId = cacheCluster.getCacheClusterId();
+        this.configurationEndpoint = cacheCluster.getConfigurationEndpoint() != null ? 
+            cacheCluster.getConfigurationEndpoint().getAddress() + ":" + cacheCluster.getConfigurationEndpoint().getPort() : null;
         this.clientDownloadLandingPage = cacheCluster.getClientDownloadLandingPage();
         this.cacheNodeType = cacheCluster.getCacheNodeType();
         this.engine = cacheCluster.getEngine();

--- a/src/main/java/com/airbnb/billow/ElasticacheCluster.java
+++ b/src/main/java/com/airbnb/billow/ElasticacheCluster.java
@@ -72,8 +72,11 @@ public class ElasticacheCluster {
 
     public ElasticacheCluster(CacheCluster cacheCluster, NodeGroupMember nodeGroupMember, List<Tag> tagList) {
         this.cacheClusterId = cacheCluster.getCacheClusterId();
-        this.configurationEndpoint = cacheCluster.getConfigurationEndpoint() != null ? 
-            cacheCluster.getConfigurationEndpoint().getAddress() + ":" + cacheCluster.getConfigurationEndpoint().getPort() : null;
+        if (cacheCluster.getConfigurationEndpoint() != null) {
+            this.configurationEndpoint = cacheCluster.getConfigurationEndpoint().toString();
+        } else {
+            this.configurationEndpoint = null;
+        }
         this.clientDownloadLandingPage = cacheCluster.getClientDownloadLandingPage();
         this.cacheNodeType = cacheCluster.getCacheNodeType();
         this.engine = cacheCluster.getEngine();

--- a/src/main/java/com/airbnb/billow/ElasticacheCluster.java
+++ b/src/main/java/com/airbnb/billow/ElasticacheCluster.java
@@ -74,8 +74,6 @@ public class ElasticacheCluster {
         this.cacheClusterId = cacheCluster.getCacheClusterId();
         if (cacheCluster.getConfigurationEndpoint() != null) {
             this.configurationEndpoint = cacheCluster.getConfigurationEndpoint().toString();
-        } else {
-            this.configurationEndpoint = null;
         }
         this.clientDownloadLandingPage = cacheCluster.getClientDownloadLandingPage();
         this.cacheNodeType = cacheCluster.getCacheNodeType();


### PR DESCRIPTION
Fix ElastiCache configurationEndpoint field

Initialize the existing configurationEndpoint field to return the actual cluster endpoint instead of always returning null.

The field now properly formats the endpoint as "address:port" when available, or null when not available.